### PR TITLE
Tighten lint: enable errcheck + errorlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,8 @@ run:
 
 linters:
   enable:
+    - errcheck
+    - errorlint
     - gocritic
     - misspell
     - prealloc
@@ -23,7 +25,6 @@ linters:
       - comments
       - common-false-positives
       - legacy
-      - std-error-handling
     paths:
       - testdata
       - third_party$

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ I've also added the ability to generate a m3u playlist from a cmus playlist.
 ## Assumptions
 
 1. I have only tested this on Linux, this should work on macOS (famous last words).
-1. Using Go 1.22.0.
+1. Using Go 1.26.
 1. Contents of '--source' path has music files that are well tagged.
 
 

--- a/cmd/organize.go
+++ b/cmd/organize.go
@@ -69,7 +69,7 @@ var organizeCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			defer f.Close()
+			defer func() { _ = f.Close() }()
 			m, err := tag.ReadFrom(f)
 			if err != nil {
 				fmt.Println(err, "-->", info.Name())

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -35,7 +35,7 @@ var versionCmd = &cobra.Command{
 				ts = s.Value
 			}
 		}
-		fmt.Fprintln(cmd.OutOrStdout(), version, sha, ts)
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), version, sha, ts)
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/heatxsink/hmuzik
 
-go 1.21.6
+go 1.26
+
+toolchain go1.26.2
 
 require (
 	github.com/dhowden/tag v0.0.0-20240122214204-713ab0e94639

--- a/internal/m3u/m3u.go
+++ b/internal/m3u/m3u.go
@@ -41,7 +41,7 @@ func (pl *Playlist) ToFile(path string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	return m3u.Execute(f, pl)
 }
 

--- a/magefile.go
+++ b/magefile.go
@@ -18,7 +18,7 @@ func init() {
 }
 
 func Clean() {
-	os.RemoveAll(name)
+	_ = os.RemoveAll(name)
 }
 
 func Vet() error {


### PR DESCRIPTION
## Summary

Follow-up to #8. Two changes folded together:

### Tighten lint

- Adds `errcheck` and `errorlint` to `.golangci.yml`.
- Drops the `std-error-handling` exclusion preset that was suppressing the very patterns `errcheck` is meant to catch (`fmt.Print*`, unchecked `defer Close()`, etc.). Without removing that preset the linters were inert — 0 issues on a codebase with several unchecked Close/Fprintln calls.
- `errorlint` had nothing left to find; the only direct sentinel comparison (`err == tag.ErrNoTagsFound`) was already swapped to `errors.Is` in #8. Kept enabled as a tripwire for future regressions.

Four `errcheck` findings surfaced and fixed:

- `cmd/organize.go:72` — `defer f.Close()` inside the `filepath.Walk` callback → `defer func() { _ = f.Close() }()`.
- `internal/m3u/m3u.go:44` — same pattern in `Playlist.ToFile`.
- `cmd/version.go:38` — `fmt.Fprintln(...)` return value explicitly discarded with `_, _ =`.
- `magefile.go:21` — `os.RemoveAll(name)` in `Clean` explicitly discarded with `_ =`.

### Bump Go

- `go.mod`'s `go` directive was still at `1.21.6` (long EOL). Floor bumped to `1.26` with an explicit `toolchain go1.26.2` pin for deterministic builds.
- README assumption updated to match.

## Test plan

- [x] `mage vet` clean
- [x] `mage lint` reports 0 issues
- [x] `mage build` produces a working binary
- [x] `hmuzik version` still emits the single-line format