### PR TITLE
Add recently-added subcommand with album-aware ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,24 @@ Convert every cmus playlist under `~/.config/cmus/playlists/` to extended m3u:
 
     $ hmuzik playlists /home/ngranado/Music/Playlists /home/ngranado
 
+Generate "recently added" cmus playlists, grouped by album and ordered by disc/track:
+
+    $ hmuzik recently-added
+
+By default this scans `$HOME/Music/Artists` and writes `recently added (NNd)`
+playlists for the windows `1, 7, 14, 30, 90` days into
+`$HOME/.config/cmus/playlists/`. Albums float to the top by most recent
+ctime; tracks within an album keep their (disc, track) order. Override with
+`-s/--source`, `-o/--output`, and `-w/--windows`. Use `-r/--dryrun` to print
+counts without writing.
+
 
 ## Layout
 
-    cmd/            cobra subcommands (root, organize, m3u, playlists)
-    internal/m3u/   m3u playlist generation
-    main.go         entry point
+    cmd/                       cobra subcommands
+    internal/m3u/              m3u playlist generation
+    internal/recentlyadded/    recently-added playlist builder
+    main.go                    entry point
 
 
 ## Collaboration

--- a/cmd/recently_added.go
+++ b/cmd/recently_added.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/heatxsink/hmuzik/internal/recentlyadded"
+	"github.com/spf13/cobra"
+)
+
+var (
+	recentlyAddedSourceOption  string
+	recentlyAddedOutputOption  string
+	recentlyAddedWindowsOption string
+	recentlyAddedDryRunOption  bool
+)
+
+var recentlyAddedCmd = &cobra.Command{
+	Use:   "recently-added",
+	Short: "Generate cmus playlists of recently-added tracks, grouped by album.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		home := os.Getenv("HOME")
+		source := recentlyAddedSourceOption
+		if source == "" {
+			source = filepath.Join(home, "Music", "Artists")
+		}
+		output := recentlyAddedOutputOption
+		if output == "" {
+			output = filepath.Join(home, ".config", "cmus", "playlists")
+		}
+		days, err := parseWindowDays(recentlyAddedWindowsOption)
+		if err != nil {
+			return err
+		}
+		maxDays := slices.Max(days)
+		now := time.Now()
+		since := now.Add(-time.Duration(maxDays) * 24 * time.Hour)
+
+		fmt.Println("Scanning:", source)
+		tracks, err := recentlyadded.Scan(source, since)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Found %d audio files within the last %d days.\n", len(tracks), maxDays)
+
+		albums := recentlyadded.GroupByAlbum(tracks)
+		fmt.Printf("Grouped into %d albums.\n", len(albums))
+
+		for _, d := range days {
+			window := time.Duration(d) * 24 * time.Hour
+			paths := recentlyadded.Playlist(albums, window, now)
+			out := filepath.Join(output, fmt.Sprintf("recently added (%02dd)", d))
+			if recentlyAddedDryRunOption {
+				fmt.Printf("[dryrun] %s: %d tracks\n", out, len(paths))
+				continue
+			}
+			if err := recentlyadded.WriteCmusPlaylist(out, paths); err != nil {
+				return fmt.Errorf("write %s: %w", out, err)
+			}
+			fmt.Printf("%s: %d tracks\n", out, len(paths))
+		}
+		return nil
+	},
+}
+
+func parseWindowDays(s string) ([]int, error) {
+	parts := strings.Split(s, ",")
+	days := make([]int, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return nil, fmt.Errorf("invalid window %q: %w", p, err)
+		}
+		if n <= 0 {
+			return nil, fmt.Errorf("invalid window %d: must be > 0", n)
+		}
+		days = append(days, n)
+	}
+	if len(days) == 0 {
+		return nil, fmt.Errorf("no windows specified")
+	}
+	slices.Sort(days)
+	return slices.Compact(days), nil
+}
+
+func init() {
+	recentlyAddedCmd.Flags().StringVarP(&recentlyAddedSourceOption, "source", "s", "", "music library root (default $HOME/Music/Artists)")
+	recentlyAddedCmd.Flags().StringVarP(&recentlyAddedOutputOption, "output", "o", "", "cmus playlist directory (default $HOME/.config/cmus/playlists)")
+	recentlyAddedCmd.Flags().StringVarP(&recentlyAddedWindowsOption, "windows", "w", "1,7,14,30,90", "comma-separated day windows")
+	recentlyAddedCmd.Flags().BoolVarP(&recentlyAddedDryRunOption, "dryrun", "r", false, "report counts without writing playlists")
+	rootCmd.AddCommand(recentlyAddedCmd)
+}

--- a/cmd/recently_added.go
+++ b/cmd/recently_added.go
@@ -41,6 +41,11 @@ var recentlyAddedCmd = &cobra.Command{
 		now := time.Now()
 		since := now.Add(-time.Duration(maxDays) * 24 * time.Hour)
 
+		if !recentlyAddedDryRunOption {
+			if err := os.MkdirAll(output, 0755); err != nil {
+				return fmt.Errorf("mkdir %s: %w", output, err)
+			}
+		}
 		fmt.Println("Scanning:", source)
 		tracks, err := recentlyadded.Scan(source, since)
 		if err != nil {

--- a/cmd/recently_added_test.go
+++ b/cmd/recently_added_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseWindowDays(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    []int
+		wantErr bool
+	}{
+		{"defaults", "1,7,14,30,90", []int{1, 7, 14, 30, 90}, false},
+		{"whitespace", " 1 , 7 , 14 ", []int{1, 7, 14}, false},
+		{"dedup", "7,1,7,14,1", []int{1, 7, 14}, false},
+		{"sorts", "30,1,7", []int{1, 7, 30}, false},
+		{"single", "5", []int{5}, false},
+		{"non-numeric", "1,abc,7", nil, true},
+		{"zero", "0,1", nil, true},
+		{"negative", "-1,7", nil, true},
+		{"empty", "", nil, true},
+		{"only-commas", ",,,", nil, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseWindowDays(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got nil (got=%v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("want %v, got %v", tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/recentlyadded/ctime_linux.go
+++ b/internal/recentlyadded/ctime_linux.go
@@ -1,0 +1,16 @@
+//go:build linux
+
+package recentlyadded
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func fileCtime(info os.FileInfo) time.Time {
+	if s, ok := info.Sys().(*syscall.Stat_t); ok {
+		return time.Unix(s.Ctim.Sec, s.Ctim.Nsec)
+	}
+	return info.ModTime()
+}

--- a/internal/recentlyadded/ctime_other.go
+++ b/internal/recentlyadded/ctime_other.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package recentlyadded
+
+import (
+	"os"
+	"time"
+)
+
+func fileCtime(info os.FileInfo) time.Time { return info.ModTime() }

--- a/internal/recentlyadded/recentlyadded.go
+++ b/internal/recentlyadded/recentlyadded.go
@@ -1,0 +1,190 @@
+package recentlyadded
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/dhowden/tag"
+)
+
+type Track struct {
+	Path        string
+	Ctime       time.Time
+	AlbumArtist string
+	Album       string
+	Disc        int
+	Track       int
+}
+
+type Album struct {
+	Key         string
+	LatestCtime time.Time
+	Tracks      []*Track
+}
+
+func isAudioFile(filename string) bool {
+	switch strings.ToLower(filepath.Ext(filename)) {
+	case ".aif", ".aiff", ".aifc", ".flac", ".m4a", ".m4p", ".mp3", ".ogg", ".wav":
+		return true
+	}
+	return false
+}
+
+// Scan walks root once and returns audio files whose ctime is at or after
+// since. Files older than since are skipped without opening (no tag read), so
+// cost scales with recent activity rather than library size. Errors on
+// individual files are logged to stderr and the walk continues.
+func Scan(root string, since time.Time) ([]*Track, error) {
+	tracks := []*Track{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "walk:", err)
+			return nil
+		}
+		if d.IsDir() || !isAudioFile(d.Name()) {
+			return nil
+		}
+		info, ierr := d.Info()
+		if ierr != nil {
+			fmt.Fprintln(os.Stderr, "stat:", path, ierr)
+			return nil
+		}
+		if info.Size() == 0 {
+			return nil
+		}
+		ctime := fileCtime(info)
+		if ctime.Before(since) {
+			return nil
+		}
+		t := &Track{Path: path, Ctime: ctime}
+		readTags(path, t)
+		tracks = append(tracks, t)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk %s: %w", root, err)
+	}
+	return tracks, nil
+}
+
+func readTags(path string, t *Track) {
+	f, err := os.Open(path)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "open:", path, err)
+		return
+	}
+	defer func() { _ = f.Close() }()
+	m, err := tag.ReadFrom(f)
+	if err != nil {
+		if !errors.Is(err, tag.ErrNoTagsFound) {
+			fmt.Fprintln(os.Stderr, "tag:", path, err)
+		}
+		return
+	}
+	t.AlbumArtist = strings.TrimSpace(m.AlbumArtist())
+	if t.AlbumArtist == "" {
+		t.AlbumArtist = strings.TrimSpace(m.Artist())
+	}
+	t.Album = strings.TrimSpace(m.Album())
+	t.Disc, _ = m.Disc()
+	t.Track, _ = m.Track()
+}
+
+// GroupByAlbum buckets tracks by (AlbumArtist, Album). Tracks missing either
+// field become single-track pseudo-albums keyed by file path so they are still
+// included but never merged with real albums. Each album's tracks are sorted
+// by (Disc, Track, Path); LatestCtime is the max ctime across its tracks.
+func GroupByAlbum(tracks []*Track) []*Album {
+	byKey := make(map[string]*Album)
+	for _, t := range tracks {
+		key := albumKey(t)
+		a, ok := byKey[key]
+		if !ok {
+			a = &Album{Key: key}
+			byKey[key] = a
+		}
+		a.Tracks = append(a.Tracks, t)
+		if t.Ctime.After(a.LatestCtime) {
+			a.LatestCtime = t.Ctime
+		}
+	}
+	albums := make([]*Album, 0, len(byKey))
+	for _, a := range byKey {
+		sort.SliceStable(a.Tracks, func(i, j int) bool {
+			ti, tj := a.Tracks[i], a.Tracks[j]
+			if ti.Disc != tj.Disc {
+				return ti.Disc < tj.Disc
+			}
+			if ti.Track != tj.Track {
+				return ti.Track < tj.Track
+			}
+			return ti.Path < tj.Path
+		})
+		albums = append(albums, a)
+	}
+	return albums
+}
+
+func albumKey(t *Track) string {
+	if t.AlbumArtist == "" || t.Album == "" {
+		return "\x00orphan\x00" + t.Path
+	}
+	return t.AlbumArtist + "\x00" + t.Album
+}
+
+// Playlist returns the ordered file paths for the given window. Tracks whose
+// ctime is older than now-window are dropped; tracks within the window retain
+// their album-internal (Disc, Track) order. Albums are ordered by
+// LatestCtime descending, with album key as a stable tiebreaker.
+func Playlist(albums []*Album, window time.Duration, now time.Time) []string {
+	cutoff := now.Add(-window)
+	type entry struct {
+		album  *Album
+		tracks []*Track
+	}
+	entries := make([]entry, 0, len(albums))
+	for _, a := range albums {
+		var kept []*Track
+		for _, t := range a.Tracks {
+			if !t.Ctime.Before(cutoff) {
+				kept = append(kept, t)
+			}
+		}
+		if len(kept) > 0 {
+			entries = append(entries, entry{album: a, tracks: kept})
+		}
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		if !entries[i].album.LatestCtime.Equal(entries[j].album.LatestCtime) {
+			return entries[i].album.LatestCtime.After(entries[j].album.LatestCtime)
+		}
+		return entries[i].album.Key < entries[j].album.Key
+	})
+	total := 0
+	for _, e := range entries {
+		total += len(e.tracks)
+	}
+	out := make([]string, 0, total)
+	for _, e := range entries {
+		for _, t := range e.tracks {
+			out = append(out, t.Path)
+		}
+	}
+	return out
+}
+
+// WriteCmusPlaylist writes paths newline-delimited to the given file. cmus
+// reads this format directly from ~/.config/cmus/playlists/.
+func WriteCmusPlaylist(path string, lines []string) error {
+	body := strings.Join(lines, "\n")
+	if len(lines) > 0 {
+		body += "\n"
+	}
+	return os.WriteFile(path, []byte(body), 0644)
+}

--- a/internal/recentlyadded/recentlyadded.go
+++ b/internal/recentlyadded/recentlyadded.go
@@ -6,7 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 	"time"
 
@@ -41,6 +41,9 @@ func isAudioFile(filename string) bool {
 // cost scales with recent activity rather than library size. Errors on
 // individual files are logged to stderr and the walk continues.
 func Scan(root string, since time.Time) ([]*Track, error) {
+	if _, err := os.Stat(root); err != nil {
+		return nil, fmt.Errorf("source %s: %w", root, err)
+	}
 	tracks := []*Track{}
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -116,15 +119,14 @@ func GroupByAlbum(tracks []*Track) []*Album {
 	}
 	albums := make([]*Album, 0, len(byKey))
 	for _, a := range byKey {
-		sort.SliceStable(a.Tracks, func(i, j int) bool {
-			ti, tj := a.Tracks[i], a.Tracks[j]
+		slices.SortStableFunc(a.Tracks, func(ti, tj *Track) int {
 			if ti.Disc != tj.Disc {
-				return ti.Disc < tj.Disc
+				return ti.Disc - tj.Disc
 			}
 			if ti.Track != tj.Track {
-				return ti.Track < tj.Track
+				return ti.Track - tj.Track
 			}
-			return ti.Path < tj.Path
+			return strings.Compare(ti.Path, tj.Path)
 		})
 		albums = append(albums, a)
 	}
@@ -160,11 +162,14 @@ func Playlist(albums []*Album, window time.Duration, now time.Time) []string {
 			entries = append(entries, entry{album: a, tracks: kept})
 		}
 	}
-	sort.SliceStable(entries, func(i, j int) bool {
-		if !entries[i].album.LatestCtime.Equal(entries[j].album.LatestCtime) {
-			return entries[i].album.LatestCtime.After(entries[j].album.LatestCtime)
+	slices.SortStableFunc(entries, func(a, b entry) int {
+		if !a.album.LatestCtime.Equal(b.album.LatestCtime) {
+			if a.album.LatestCtime.After(b.album.LatestCtime) {
+				return -1
+			}
+			return 1
 		}
-		return entries[i].album.Key < entries[j].album.Key
+		return strings.Compare(a.album.Key, b.album.Key)
 	})
 	total := 0
 	for _, e := range entries {

--- a/internal/recentlyadded/recentlyadded_test.go
+++ b/internal/recentlyadded/recentlyadded_test.go
@@ -1,0 +1,165 @@
+package recentlyadded
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func tk(path, aa, alb string, disc, track int, t time.Time) *Track {
+	return &Track{Path: path, AlbumArtist: aa, Album: alb, Disc: disc, Track: track, Ctime: t}
+}
+
+func TestGroupByAlbum_BucketsAndSorts(t *testing.T) {
+	now := time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC)
+	tracks := []*Track{
+		tk("/a/3.flac", "ArtistA", "AlbumA", 1, 3, now.Add(-3*24*time.Hour)),
+		tk("/a/1.flac", "ArtistA", "AlbumA", 1, 1, now.Add(-1*24*time.Hour)),
+		tk("/a/2.flac", "ArtistA", "AlbumA", 1, 2, now.Add(-2*24*time.Hour)),
+		tk("/b/1.flac", "ArtistB", "AlbumB", 1, 1, now.Add(-10*24*time.Hour)),
+	}
+	albums := GroupByAlbum(tracks)
+	if len(albums) != 2 {
+		t.Fatalf("want 2 albums, got %d", len(albums))
+	}
+	var a *Album
+	for _, al := range albums {
+		if al.Key == "ArtistA\x00AlbumA" {
+			a = al
+		}
+	}
+	if a == nil {
+		t.Fatal("missing ArtistA/AlbumA")
+	}
+	wantOrder := []string{"/a/1.flac", "/a/2.flac", "/a/3.flac"}
+	got := []string{a.Tracks[0].Path, a.Tracks[1].Path, a.Tracks[2].Path}
+	if !reflect.DeepEqual(got, wantOrder) {
+		t.Errorf("track order: want %v, got %v", wantOrder, got)
+	}
+	if !a.LatestCtime.Equal(now.Add(-1 * 24 * time.Hour)) {
+		t.Errorf("LatestCtime: want %v, got %v", now.Add(-1*24*time.Hour), a.LatestCtime)
+	}
+}
+
+func TestGroupByAlbum_TaglessAreOrphans(t *testing.T) {
+	now := time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC)
+	tracks := []*Track{
+		tk("/orphan/x.mp3", "", "", 0, 0, now),
+		tk("/orphan/y.mp3", "", "", 0, 0, now),
+		tk("/known/1.flac", "ArtistA", "AlbumA", 1, 1, now),
+	}
+	albums := GroupByAlbum(tracks)
+	if len(albums) != 3 {
+		t.Fatalf("want 3 albums (2 orphans + 1 real), got %d", len(albums))
+	}
+}
+
+func TestGroupByAlbum_AlbumArtistDistinguishesCompilations(t *testing.T) {
+	now := time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC)
+	tracks := []*Track{
+		tk("/c/1.flac", "Various Artists", "Comp1", 1, 1, now),
+		tk("/c/2.flac", "Various Artists", "Comp1", 1, 2, now),
+	}
+	albums := GroupByAlbum(tracks)
+	if len(albums) != 1 {
+		t.Fatalf("want 1 compilation album, got %d", len(albums))
+	}
+}
+
+func TestPlaylist_WindowFiltering(t *testing.T) {
+	now := time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC)
+	tracks := []*Track{
+		tk("/a/1.flac", "ArtistA", "AlbumA", 1, 1, now.Add(-12*time.Hour)),
+		tk("/a/2.flac", "ArtistA", "AlbumA", 1, 2, now.Add(-3*24*time.Hour)),
+		tk("/a/3.flac", "ArtistA", "AlbumA", 1, 3, now.Add(-10*24*time.Hour)),
+	}
+	albums := GroupByAlbum(tracks)
+
+	got := Playlist(albums, 24*time.Hour, now)
+	if !reflect.DeepEqual(got, []string{"/a/1.flac"}) {
+		t.Errorf("1d window: want only /a/1.flac, got %v", got)
+	}
+
+	got = Playlist(albums, 7*24*time.Hour, now)
+	if !reflect.DeepEqual(got, []string{"/a/1.flac", "/a/2.flac"}) {
+		t.Errorf("7d window: want 1.flac then 2.flac in album order, got %v", got)
+	}
+
+	got = Playlist(albums, 30*24*time.Hour, now)
+	if !reflect.DeepEqual(got, []string{"/a/1.flac", "/a/2.flac", "/a/3.flac"}) {
+		t.Errorf("30d window: want all in album order, got %v", got)
+	}
+}
+
+func TestPlaylist_AlbumOrderByRecency(t *testing.T) {
+	now := time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC)
+	tracks := []*Track{
+		tk("/old/1.flac", "Old", "Old", 1, 1, now.Add(-20*24*time.Hour)),
+		tk("/old/2.flac", "Old", "Old", 1, 2, now.Add(-25*24*time.Hour)),
+		tk("/new/1.flac", "New", "New", 1, 1, now.Add(-2*24*time.Hour)),
+		tk("/new/2.flac", "New", "New", 1, 2, now.Add(-3*24*time.Hour)),
+	}
+	albums := GroupByAlbum(tracks)
+	got := Playlist(albums, 30*24*time.Hour, now)
+	want := []string{"/new/1.flac", "/new/2.flac", "/old/1.flac", "/old/2.flac"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("album order: want %v, got %v", want, got)
+	}
+}
+
+func TestPlaylist_PartialAlbumKeepsAlbumPosition(t *testing.T) {
+	now := time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC)
+	// Album with tracks 1..5, only track 3 was re-touched yesterday.
+	tracks := []*Track{
+		tk("/a/1.flac", "ArtistA", "AlbumA", 1, 1, now.Add(-200*24*time.Hour)),
+		tk("/a/2.flac", "ArtistA", "AlbumA", 1, 2, now.Add(-200*24*time.Hour)),
+		tk("/a/3.flac", "ArtistA", "AlbumA", 1, 3, now.Add(-12*time.Hour)),
+		tk("/a/4.flac", "ArtistA", "AlbumA", 1, 4, now.Add(-200*24*time.Hour)),
+		tk("/a/5.flac", "ArtistA", "AlbumA", 1, 5, now.Add(-200*24*time.Hour)),
+	}
+	albums := GroupByAlbum(tracks)
+	got := Playlist(albums, 24*time.Hour, now)
+	if !reflect.DeepEqual(got, []string{"/a/3.flac"}) {
+		t.Errorf("partial album: want only /a/3.flac, got %v", got)
+	}
+}
+
+func TestPlaylist_MultiDiscOrdering(t *testing.T) {
+	now := time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC)
+	tracks := []*Track{
+		tk("/a/d2t2.flac", "ArtistA", "AlbumA", 2, 2, now.Add(-1*time.Hour)),
+		tk("/a/d1t2.flac", "ArtistA", "AlbumA", 1, 2, now.Add(-1*time.Hour)),
+		tk("/a/d2t1.flac", "ArtistA", "AlbumA", 2, 1, now.Add(-1*time.Hour)),
+		tk("/a/d1t1.flac", "ArtistA", "AlbumA", 1, 1, now.Add(-1*time.Hour)),
+	}
+	albums := GroupByAlbum(tracks)
+	got := Playlist(albums, 24*time.Hour, now)
+	want := []string{"/a/d1t1.flac", "/a/d1t2.flac", "/a/d2t1.flac", "/a/d2t2.flac"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("multi-disc order: want %v, got %v", want, got)
+	}
+}
+
+func TestIsAudioFile(t *testing.T) {
+	cases := map[string]bool{
+		"song.flac":     true,
+		"song.FLAC":     true,
+		"song.mp3":      true,
+		"song.m4a":      true,
+		"song.m4p":      true,
+		"song.aif":      true,
+		"song.aiff":     true,
+		"song.aifc":     true,
+		"song.ogg":      true,
+		"song.wav":      true,
+		"cover.jpg":     false,
+		"notes.txt":     false,
+		"song":          false,
+		"song.flac.bak": false,
+	}
+	for name, want := range cases {
+		if got := isAudioFile(name); got != want {
+			t.Errorf("isAudioFile(%q) = %v, want %v", name, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the `cmus-recently-added` bash script with a Go subcommand. The bash version walked the library five times and sorted purely by filesystem ctime — tracks from the same album ended up scattered across the playlist (track 7 of album A, then track 2 of album B, then track 1 of album A). The new command walks once, groups by `(AlbumArtist, Album)`, sorts within each album by `(Disc, Track)`, and orders albums by most-recent ctime.

### Design

- **Single pass** over the library (`filepath.WalkDir`), filtered to audio extensions matching the bash script's set (`aif, aiff, aifc, flac, m4a, m4p, mp3, ogg, wav`).
- **ctime** comes from `syscall.Stat_t.Ctim` on Linux to match `stat -c %Z`. Non-Linux platforms fall back to mtime.
- **Tag-less or untagged files** become single-track pseudo-albums keyed by file path so they're included but never merged with real albums.
- **AlbumArtist preferred over Artist** so compilations (Various Artists) group correctly.
- **Partial-album semantics: conservative.** A 1d window contains only the tracks whose own ctime is within 24h, sorted in their (Disc, Track) album position. Re-tagging one track surfaces only that track, not the whole album. (Alternative semantics — whole album if any track qualifies — would flood the short windows after any bulk re-tag.)
- **Files older than the largest window are skipped without opening**, so tag-read cost scales with recent activity, not library size.

### CLI

```
hmuzik recently-added \
  [-s|--source $HOME/Music/Artists] \
  [-o|--output $HOME/.config/cmus/playlists] \
  [-w|--windows 1,7,14,30,90] \
  [-r|--dryrun]
```

Output files match the bash script naming: ` recently added (01d)`, `(07d)`, `(14d)`, `(30d)`, `(90d)`.

### Package layout

- `internal/recentlyadded/recentlyadded.go` — types, `Scan`, `GroupByAlbum`, `Playlist`, `WriteCmusPlaylist`.
- `internal/recentlyadded/ctime_linux.go` — Linux ctime via `syscall.Stat_t.Ctim` (`//go:build linux`).
- `internal/recentlyadded/ctime_other.go` — mtime fallback for non-Linux builds.
- `internal/recentlyadded/recentlyadded_test.go` — 8 table-driven tests.

### Test plan

- [x] `mage vet` clean
- [x] `mage lint` reports 0 issues
- [x] `mage test` — 8 tests pass (bucketing, orphans, compilations, window filtering, recency ordering, partial-album semantics, multi-disc ordering, audio-extension matcher)
- [x] `mage build` produces a working binary
- [x] `hmuzik recently-added --help` documents all four flags
- [x] `hmuzik recently-added --dryrun --output /tmp` against the real `$HOME/Music/Artists` reports plausible counts (242 files, 17 albums across the 90d window)
- [ ] Manual: run without `--dryrun` and confirm cmus renders the five generated playlists with proper album-internal ordering